### PR TITLE
docs: update version references to v0.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create or update a workflow, adding the file `.github/workflows/doorkeeper.yml` 
 
 - name: Doorkeeper open
   id: doorkeeper_open
-  uses: patoroco/doorkeeper@v0.4.0
+  uses: patoroco/doorkeeper@v0.4.1
   with:
     digitaloceanToken: ${{ secrets.DO_TOKEN }}
     firewallName: "name_of_the_firewall"
@@ -42,7 +42,7 @@ Create or update a workflow, adding the file `.github/workflows/doorkeeper.yml` 
 ############################
 
 - name: Doorkeeper close
-  uses: patoroco/doorkeeper@v0.4.0
+  uses: patoroco/doorkeeper@v0.4.1
   with:
     digitaloceanToken: ${{ secrets.DO_TOKEN }}
     firewallName: "name_of_the_firewall"
@@ -81,7 +81,7 @@ This is useful when you want to ensure the same IP is removed in a cleanup step,
 ```yaml
 - name: Doorkeeper open
   id: doorkeeper
-  uses: patoroco/doorkeeper@v0.4.0
+  uses: patoroco/doorkeeper@v0.4.1
   with:
     digitaloceanToken: ${{ secrets.DO_TOKEN }}
     firewallName: "my-firewall"
@@ -91,7 +91,7 @@ This is useful when you want to ensure the same IP is removed in a cleanup step,
 
 - name: Doorkeeper close
   if: always()  # Run even if previous steps fail
-  uses: patoroco/doorkeeper@v0.4.0
+  uses: patoroco/doorkeeper@v0.4.1
   with:
     digitaloceanToken: ${{ secrets.DO_TOKEN }}
     firewallName: "my-firewall"


### PR DESCRIPTION
Updates all version references in the README from v0.4.0 to v0.4.1 to reflect the latest security release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates documentation to reference the latest action version.
> 
> - Replace `patoroco/doorkeeper@v0.4.0` with `patoroco/doorkeeper@v0.4.1` in README workflow examples (`Doorkeeper open`/`close` and the outputs example)
> - No code changes; README usage snippets now consistently point to `v0.4.1`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5bdf6ec160d21bd766a75ff5b44f21fcfbb7a32d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->