### PR TITLE
feat: preserve droplet_ids and tags in firewall rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "digitalocean-doorkeeper",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "This Github action allows you to open or close an specific port in your DigitalOcean firewall. It's really useful for deploy in your instances from Github Actions, as they don't provide a list of IPs to add to your security groups.",
   "main": "src/main.ts",
   "scripts": {

--- a/src/digitalocean.ts
+++ b/src/digitalocean.ts
@@ -58,6 +58,9 @@ function applyRule(config: ActionConfig, rule: IFirewallInboundRule = { protocol
   if (!cloneRule.sources.addresses) {
     cloneRule.sources.addresses = [];
   }
+  if (!cloneRule.sources.droplet_ids) {
+    cloneRule.sources.droplet_ids = rule.sources?.droplet_ids || [];
+  }
 
   const addresses = cloneRule.sources.addresses;
   if (action == "add") {
@@ -66,10 +69,10 @@ function applyRule(config: ActionConfig, rule: IFirewallInboundRule = { protocol
     }
   } else if (action == "remove") {
     cloneRule.sources.addresses = addresses.filter((address: string) => address != IP);
-
   }
 
-  if (cloneRule.sources?.addresses.length == 0) {
+  // Only return null if both addresses and droplet_ids are empty
+  if (cloneRule.sources?.addresses.length === 0 && (!cloneRule.sources?.droplet_ids || cloneRule.sources.droplet_ids.length === 0)) {
     return null;
   }
 
@@ -79,25 +82,25 @@ function applyRule(config: ActionConfig, rule: IFirewallInboundRule = { protocol
 export function generateInboundRules(oldRules: IFirewallInboundRule[] = [], config: ActionConfig): IFirewallInboundRule[] {
   const { port, action, protocol } = config;
   const existingRules = oldRules.filter(r => r.ports == port.toString() && r.protocol == protocol);
+  const otherRules = oldRules.filter(r => r.ports != port.toString() || r.protocol != protocol);
 
   if (!existingRules.length) {
     const newRule = applyRule(config);
     if (newRule) {
-      oldRules.push(newRule);
+      return [...otherRules, newRule];
     }
-    return oldRules;
+    return otherRules;
   }
 
-  return oldRules.reduce((out, r, index) => {
-    if (action == "remove" || (action == "add" && index == 0)) {
-      const newRule = applyRule(config, r);
-      if (newRule)
-        out.push(newRule)
-    } else {
-      out.push(r);
+  const updatedRules = existingRules.reduce((out, r) => {
+    const newRule = applyRule(config, r);
+    if (newRule) {
+      out.push(newRule);
     }
     return out;
   }, [] as IFirewallInboundRule[]);
+
+  return [...otherRules, ...updatedRules];
 }
 
 export async function updateInboundRules(
@@ -114,8 +117,10 @@ export async function updateInboundRules(
 
   const updated = {
     ...firewall,
-    inbound_rules: inboundRules.length ? inboundRules : [],
-    outbound_rules: prepareOutboundRules(firewall.outbound_rules)
+    inbound_rules: inboundRules,
+    outbound_rules: prepareOutboundRules(firewall.outbound_rules),
+    droplet_ids: firewall.droplet_ids,
+    tags: firewall.tags
   };
 
   try {
@@ -162,7 +167,10 @@ export function printFirewallRules(inboundRules: IFirewallInboundRule[] = [], ti
     console.log("** no rules defined **");
   }
   inboundRules.forEach(rule => {
-    console.log(`${rule.ports}::${rule.protocol} - ${rule.sources?.addresses}`);
+    const addresses = rule.sources?.addresses?.length ? `IPs: ${rule.sources.addresses}` : '';
+    const droplets = rule.sources?.droplet_ids?.length ? `Droplets: ${rule.sources.droplet_ids}` : '';
+    const sources = [addresses, droplets].filter(Boolean).join(', ');
+    console.log(`${rule.ports}::${rule.protocol} - ${sources || 'No sources'}`);
   });
 }
 


### PR DESCRIPTION
## Summary

This PR integrates the changes from PR #37 by @fjpedrosa to preserve droplet_ids when updating firewall rules.

## Changes

- **Preserve droplet_ids** when updating firewall rules - previously these were lost
- **Only remove a rule** if both addresses AND droplet_ids are empty
- **Preserve droplet_ids and tags** when calling the updateFirewall API
- **Improved logging** to show both IPs and Droplet IDs in the output
- **Refactored generateInboundRules** for cleaner logic

## Why this matters

Previously, if you had a firewall rule that allowed access from both IPs and specific Droplets, updating the rule would lose the droplet_ids. This fix ensures all sources are preserved.

Closes #37

## Credit

Based on the original work by @fjpedrosa in PR #37.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures firewall sources are preserved and rule updates are accurate.
> 
> - `applyRule`: retains existing `sources.droplet_ids`; only drops a rule if both `addresses` and `droplet_ids` are empty
> - `generateInboundRules`: separates matching vs other rules; updates only matching rules and reconstructs the full set
> - `updateInboundRules`: sends `inbound_rules` as-is and preserves `droplet_ids` and `tags` in the update payload
> - `printFirewallRules`: logs both IPs and Droplet IDs (or "No sources")
> - Bumps version to `0.5.0`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed03b34f38125a4a9ed824c8533547267c0854d2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->