### PR TITLE
docs: update version references to v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Create or update a workflow, adding the file `.github/workflows/doorkeeper.yml` 
 
 - name: Doorkeeper open
   id: doorkeeper_open
-  uses: patoroco/doorkeeper@v0.4.1
+  uses: patoroco/doorkeeper@v0.5.0
   with:
     digitaloceanToken: ${{ secrets.DO_TOKEN }}
     firewallName: "name_of_the_firewall"
@@ -42,7 +42,7 @@ Create or update a workflow, adding the file `.github/workflows/doorkeeper.yml` 
 ############################
 
 - name: Doorkeeper close
-  uses: patoroco/doorkeeper@v0.4.1
+  uses: patoroco/doorkeeper@v0.5.0
   with:
     digitaloceanToken: ${{ secrets.DO_TOKEN }}
     firewallName: "name_of_the_firewall"
@@ -81,7 +81,7 @@ This is useful when you want to ensure the same IP is removed in a cleanup step,
 ```yaml
 - name: Doorkeeper open
   id: doorkeeper
-  uses: patoroco/doorkeeper@v0.4.1
+  uses: patoroco/doorkeeper@v0.5.0
   with:
     digitaloceanToken: ${{ secrets.DO_TOKEN }}
     firewallName: "my-firewall"
@@ -91,7 +91,7 @@ This is useful when you want to ensure the same IP is removed in a cleanup step,
 
 - name: Doorkeeper close
   if: always()  # Run even if previous steps fail
-  uses: patoroco/doorkeeper@v0.4.1
+  uses: patoroco/doorkeeper@v0.5.0
   with:
     digitaloceanToken: ${{ secrets.DO_TOKEN }}
     firewallName: "my-firewall"


### PR DESCRIPTION
Updates all version references in the README from v0.4.1 to v0.5.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README usage examples to reference `patoroco/doorkeeper@v0.5.0`.
> 
> - Bumps action version in both "Doorkeeper open/close" examples in `Usage`
> - Updates the outputs example to use `@v0.5.0` for open/close steps
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65bc5e09c91cf4b5724e69557f229c2a75a35531. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->